### PR TITLE
fix: empty style tag no longer throws error

### DIFF
--- a/packages/dom-element-to-react/src/staticToReactElement.ts
+++ b/packages/dom-element-to-react/src/staticToReactElement.ts
@@ -51,7 +51,7 @@ export default async (el: Element, recursor: StaticToReactElementRecursor) => {
         {}
       );
 
-    if (attributes.style) {
+    if ("style" in attributes) {
       attributes = bootstrapStyles(attributes);
     }
 


### PR DESCRIPTION
if `<p style="" />` were to be parsed this invalid `style` prop would reach React and an error would be thrown, stopping rehydration