### PR TITLE
fix: don't output __tests__ in lib

### DIFF
--- a/packages/dom-element-to-react/tsconfig.json
+++ b/packages/dom-element-to-react/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "lib"
   },
 
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__"]
 }

--- a/packages/react-from-markup/tsconfig.json
+++ b/packages/react-from-markup/tsconfig.json
@@ -5,5 +5,6 @@
     "outDir": "lib"
   },
 
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/__tests__"]
 }


### PR DESCRIPTION
`tsc` will, by default, compile anything ending with `.ts` into the `lib` directory. This can include the unit tests. However, it _won't_ copy the snapshots.

There were two options to solve this:
1. Stop compiling `__tests__` into `lib`
2. Ignore `lib` in Jest

Option 1 won, simply because it means spending less time compiling.