### PR TITLE
feat: support custom rehydratable query selectors

### DIFF
--- a/packages/react-from-markup/src/ILoadedOptions.ts
+++ b/packages/react-from-markup/src/ILoadedOptions.ts
@@ -1,0 +1,7 @@
+interface IOptions {
+  allSelectors: { [key: string]: string };
+  compoundSelector: string;
+  extra: object;
+}
+
+export default IOptions;

--- a/packages/react-from-markup/src/IOptions.ts
+++ b/packages/react-from-markup/src/IOptions.ts
@@ -1,5 +1,6 @@
 interface IOptions {
   extra: object;
+  getQuerySelector?: (key: string) => string;
 }
 
 export default IOptions;


### PR DESCRIPTION
Blocked by #48, and have based this on that.

---

## What?

Enables custom query selectors, which can eliminate any custom markup.

Instead of this

```html
<html>
  <body>
    <div class="Clock" data-rehydratable="Clock">
      15:21:11
    </div>
  </body>
</html>
```

You can now have this

```html
<html>
  <body>
    <div class="Clock">
      15:21:11
    </div>
  </body>
</html>
```

By configuring your rehydrate method with the new `getQuerySelector()` method

```js
import rehydrate from 'react-from-markup';
import { ClockRehydrator } from 'my-components';

rehydrate(
  root,
  {
    Clock: ClockRehydrator
  },
  {
    getQuerySelector: key => `.${key}`
  }
);
```

## How?

This PR extends replaces reading of the `data-rehydratable` attribute with a query selector. By default, this query selector will check for `data-rehydratable`, but this can be overridden using the `getQuerySelector` param.

You can get quite creative with your selectors, targeting whatever you want.

## Breaking changes

This PR contains no breaking changes

## Considerations

There is a slight performance penalty to doing this instead of reading the `data-rehydratable` attribute directly, in particular due to the introduction of some new loops. I'll do my best to point them out via PR line comments.

## TODO
* [ ] Tests
* [ ] Docs